### PR TITLE
Exclude views from deleted tables

### DIFF
--- a/table_schema.go
+++ b/table_schema.go
@@ -55,7 +55,7 @@ func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables
 		SELECT T.TABLE_NAME, T.PARENT_TABLE_NAME, T.ON_DELETE_ACTION, IF(F.Referencing IS NULL, ARRAY<STRING>[], F.Referencing) AS referencedBy
 		FROM INFORMATION_SCHEMA.TABLES AS T
 		LEFT OUTER JOIN FKReferences AS F ON T.TABLE_NAME = F.Referenced
-		WHERE T.TABLE_CATALOG = "" AND T.TABLE_SCHEMA = ""
+		WHERE T.TABLE_CATALOG = "" AND T.TABLE_SCHEMA = "" AND T.TABLE_TYPE = "BASE TABLE"
 		ORDER BY T.TABLE_NAME ASC
 	`))
 


### PR DESCRIPTION
[Cloud Spanner View](https://cloud.google.com/spanner/docs/views) is a logical view and doesn't have actual data, so spanner-truncate must exclude views from deleted tables. Currently tables are fetched from [INFORMATION_SCHEMA.TABLES](https://cloud.google.com/spanner/docs/information-schema#information_schematables) and it can contain view tables.

## Before

```
$ spanner-truncate -p ${PROJECT} -i ${INSTANCE} -d ${DATABASE}                                                                
Fetching table schema from xxx                                                                                                                                                                          
SingerNames                                                                                                                          
Singers   
                                                                  
Rows in these tables will be deleted. Do you want to continue? [Y/n] Y
SingerNames:      waiting       0s [--------------------------------------------------------------------]   0% (0 / 1)
Singers:          waiting       0s [--------------------------------------------------------------------]   0% (0 / 1)
ERROR: failed to delete: rpc error: code = InvalidArgument desc = DML not supported for views.
```

## After

```
$ spanner-truncate -p ${PROJECT} -i ${INSTANCE} -d ${DATABASE}   
Fetching table schema from xxx
Singers

Rows in these tables will be deleted. Do you want to continue? [Y/n] Y
Singers: completed     4s [====================================================================] 100% (1 / 1)

Done! All rows have been deleted successfully.
```