### PR TITLE
Add missing client.Close()

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func run(ctx context.Context, projectID, instanceID, databaseID string, quiet bo
 	if err != nil {
 		return fmt.Errorf("failed to create Cloud Spanner client: %v", err)
 	}
+	defer client.Close()
 
 	fmt.Fprintf(out, "Fetching table schema from %s\n", database)
 	schemas, err := fetchTableSchemas(ctx, client, targetTables)


### PR DESCRIPTION
Fixed to call `defer client.Close()` when creating a spanner client.