### PR TITLE
[Feature] Add `--exclude-tables, -e` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Application Options:
   -d, --database= (required) Cloud Spanner Database ID.
   -q, --quiet     Disable all interactive prompts.
   -t, --tables=   Comma separated table names to be truncated. Default to truncate all tables if not specified.
-
+  -w, --whitelist Comma separated table names to be exempted from truncating. 'tables' and 'whitelist' cannot co-exist.
 Help Options:
   -h, --help      Show this help message
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Application Options:
   -d, --database= (required) Cloud Spanner Database ID.
   -q, --quiet     Disable all interactive prompts.
   -t, --tables=   Comma separated table names to be truncated. Default to truncate all tables if not specified.
-  -w, --whitelist Comma separated table names to be exempted from truncating. 'tables' and 'whitelist' cannot co-exist.
+  -e, --exclude-tables Comma separated table names to be exempted from truncating. 'tables' and 'exclude-tables' cannot co-exist.
 Help Options:
   -h, --help      Show this help message
 ```

--- a/integration_test.go
+++ b/integration_test.go
@@ -197,7 +197,7 @@ func TestIntegrationTest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open /dev/null: %v", err)
 	}
-	if err := run(ctx, testProjectID, testInstanceID, testDatabaseID, true, devNull, nil); err != nil {
+	if err := run(ctx, testProjectID, testInstanceID, testDatabaseID, true, devNull, nil, nil); err != nil {
 		t.Fatalf("run spanner-truncate failed: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	if opts.ExcludeTables != "" {
 		if opts.Tables != "" {
-			exitf("Conflict: -t and -w cannot be both set.\n")
+			exitf("Conflict: --tables and --exclude-tables cannot be both set.\n")
 		}
 		excludeTables = strings.Split(opts.ExcludeTables, ",")
 	}

--- a/main.go
+++ b/main.go
@@ -33,12 +33,12 @@ import (
 )
 
 type options struct {
-	ProjectID  string `short:"p" long:"project" description:"(required) GCP Project ID."`
-	InstanceID string `short:"i" long:"instance" description:"(required) Cloud Spanner Instance ID."`
-	DatabaseID string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
-	Quiet      bool   `short:"q" long:"quiet" description:"Disable all interactive prompts."`
-	Tables     string `short:"t" long:"tables" description:"Comma separated table names to be truncated. Default to truncate all tables if not specified."`
-	Whitelist  string `short:"w" long:"whitelist" description:"Comma separated table names to be exempted from truncating. 'tables' and 'whitelist' cannot co-exist"`
+	ProjectID     string `short:"p" long:"project" description:"(required) GCP Project ID."`
+	InstanceID    string `short:"i" long:"instance" description:"(required) Cloud Spanner Instance ID."`
+	DatabaseID    string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
+	Quiet         bool   `short:"q" long:"quiet" description:"Disable all interactive prompts."`
+	Tables        string `short:"t" long:"tables" description:"Comma separated table names to be truncated. Default to truncate all tables if not specified."`
+	ExcludeTables string `short:"e" long:"exclude-tables" description:"Comma separated table names to be exempted from truncating. 'tables' and 'exclude-tables' cannot co-exist"`
 }
 
 const maxTimeout = time.Hour * 24
@@ -54,30 +54,28 @@ func main() {
 	}
 
 	var targetTables []string
-	var whitelistedTables []string
+	var excludeTables []string
 	if opts.Tables != "" {
 		targetTables = strings.Split(opts.Tables, ",")
 	}
 
-	targetTables = append(targetTables, []string{"foo", "bar", "baz"}...)
-
-	if opts.Whitelist != "" {
+	if opts.ExcludeTables != "" {
 		if opts.Tables != "" {
 			exitf("Conflict: -t and -w cannot be both set.\n")
 		}
-		whitelistedTables = strings.Split(opts.Whitelist, ",")
+		excludeTables = strings.Split(opts.ExcludeTables, ",")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), maxTimeout)
 	defer cancel()
 	go handleInterrupt(cancel)
 
-	if err := run(ctx, opts.ProjectID, opts.InstanceID, opts.DatabaseID, opts.Quiet, os.Stdout, targetTables, whitelistedTables); err != nil {
+	if err := run(ctx, opts.ProjectID, opts.InstanceID, opts.DatabaseID, opts.Quiet, os.Stdout, targetTables, excludeTables); err != nil {
 		exitf("ERROR: %s", err.Error())
 	}
 }
 
-func run(ctx context.Context, projectID, instanceID, databaseID string, quiet bool, out io.Writer, targetTables, whitelistedTables []string) error {
+func run(ctx context.Context, projectID, instanceID, databaseID string, quiet bool, out io.Writer, targetTables, excludeTables []string) error {
 	database := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, databaseID)
 
 	client, err := spanner.NewClient(ctx, database)
@@ -87,7 +85,7 @@ func run(ctx context.Context, projectID, instanceID, databaseID string, quiet bo
 	defer client.Close()
 
 	fmt.Fprintf(out, "Fetching table schema from %s\n", database)
-	schemas, err := fetchTableSchemas(ctx, client, targetTables, whitelistedTables)
+	schemas, err := fetchTableSchemas(ctx, client, targetTables, excludeTables)
 	if err != nil {
 		return fmt.Errorf("failed to fetch table schema: %v", err)
 	}

--- a/table_schema.go
+++ b/table_schema.go
@@ -42,7 +42,7 @@ type tableSchema struct {
 	referencedBy []string
 }
 
-func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables []string) ([]*tableSchema, error) {
+func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables, whitelistedTables []string) ([]*tableSchema, error) {
 	// This query fetches the table metadata and relationships.
 	iter := client.Single().Query(ctx, spanner.NewStatement(`
 		WITH FKReferences AS (
@@ -61,7 +61,8 @@ func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables
 
 	truncateAll := true
 	targets := make(map[string]bool, len(targetTables))
-	if len(targetTables) > 0 {
+	whitelists := make(map[string]bool, len(whitelistedTables))
+	if len(targetTables) > 0 || len(whitelistedTables) > 0 {
 		truncateAll = false
 		for _, t := range targetTables {
 			targets[t] = true
@@ -81,6 +82,9 @@ func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables
 		}
 
 		if !truncateAll {
+			if _, ok := whitelists[tableName]; ok {
+				return nil
+			}
 			if _, ok := targets[tableName]; !ok {
 				return nil
 			}

--- a/table_schema.go
+++ b/table_schema.go
@@ -42,7 +42,7 @@ type tableSchema struct {
 	referencedBy []string
 }
 
-func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables, whitelistedTables []string) ([]*tableSchema, error) {
+func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables, excludeTables []string) ([]*tableSchema, error) {
 	// This query fetches the table metadata and relationships.
 	iter := client.Single().Query(ctx, spanner.NewStatement(`
 		WITH FKReferences AS (
@@ -61,11 +61,14 @@ func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables
 
 	truncateAll := true
 	targets := make(map[string]bool, len(targetTables))
-	whitelists := make(map[string]bool, len(whitelistedTables))
-	if len(targetTables) > 0 || len(whitelistedTables) > 0 {
+	excludes := make(map[string]bool, len(excludeTables))
+	if len(targetTables) > 0 || len(excludeTables) > 0 {
 		truncateAll = false
 		for _, t := range targetTables {
 			targets[t] = true
+		}
+		for _, t := range excludeTables {
+			excludes[t] = true
 		}
 	}
 
@@ -82,11 +85,14 @@ func fetchTableSchemas(ctx context.Context, client *spanner.Client, targetTables
 		}
 
 		if !truncateAll {
-			if _, ok := whitelists[tableName]; ok {
-				return nil
-			}
-			if _, ok := targets[tableName]; !ok {
-				return nil
+			if len(excludes) != 0 {
+				if _, ok := excludes[tableName]; ok {
+					return nil
+				}
+			} else {
+				if _, ok := targets[tableName]; !ok {
+					return nil
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR adds a `--exclude-tables, -e` flag to accept a list of Spanner table names to be exempted from truncating.

This flag comes in handy when the database contains a huge amount of tables and only a few tables not need to be purged (eg: tables store database migrations information).

Example:

_Database with Table0 ~ Table99, where Table 98 and 99 do not need to be purged._

**Current**
```sh
spanner-truncate -i <INSTANCE> -p <PROJECT> -d <DATABASE> -q --tables Table1,Table2,Table3....Table97
```

**With `--exclude-tables` flag**
```sh
spanner-truncate -i <INSTANCE> -p <PROJECT> -d <DATABASE> -q --exclude-tables Table98, Table99
```