### PR TITLE
Add environment variables for project, instance, and database options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Usage:
   spanner-truncate [OPTIONS]
 
 Application Options:
-  -p, --project=  (required) GCP Project ID.
-  -i, --instance= (required) Cloud Spanner Instance ID.
-  -d, --database= (required) Cloud Spanner Database ID.
+  -p, --project=  (required) GCP Project ID. [$SPANNER_PROJECT_ID]
+  -i, --instance= (required) Cloud Spanner Instance ID. [$SPANNER_INSTANCE_ID]
+  -d, --database= (required) Cloud Spanner Database ID. [$SPANNER_DATABASE_ID]
   -q, --quiet     Disable all interactive prompts.
   -t, --tables=   Comma separated table names to be truncated. Default to truncate all tables if not specified.
   -e, --exclude-tables Comma separated table names to be exempted from truncating. 'tables' and 'exclude-tables' cannot co-exist.

--- a/main.go
+++ b/main.go
@@ -33,9 +33,9 @@ import (
 )
 
 type options struct {
-	ProjectID     string `short:"p" long:"project" description:"(required) GCP Project ID."`
-	InstanceID    string `short:"i" long:"instance" description:"(required) Cloud Spanner Instance ID."`
-	DatabaseID    string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
+	ProjectID     string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
+	InstanceID    string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID."`
+	DatabaseID    string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
 	Quiet         bool   `short:"q" long:"quiet" description:"Disable all interactive prompts."`
 	Tables        string `short:"t" long:"tables" description:"Comma separated table names to be truncated. Default to truncate all tables if not specified."`
 	ExcludeTables string `short:"e" long:"exclude-tables" description:"Comma separated table names to be exempted from truncating. 'tables' and 'exclude-tables' cannot co-exist"`


### PR DESCRIPTION
The changeset added environment variables:

- `SPANNER_PROJECT_ID` as alternative to `-p` option
- `SPANNER_INSTANCE_ID` as alternative to `-i` option
- `SPANNER_DATABASE_ID` as alternative to `-d` option