### PR TITLE
Fix child table not deleted with --tables option

### DIFF
--- a/coordinator_test.go
+++ b/coordinator_test.go
@@ -61,6 +61,17 @@ func TestNewCoordinator(t *testing.T) {
 			},
 		},
 		{
+			desc: "Only child table specified in multiple tables",
+			schemas: []*tableSchema{
+				{tableName: "C", parentTableName: "B"},
+				{tableName: "D", parentTableName: "A"},
+			},
+			want: []*table{
+				{tableName: "C"},
+				{tableName: "D"},
+			},
+		},
+		{
 			desc: "Only child table specified in two levels",
 			schemas: []*tableSchema{
 				{tableName: "C", parentTableName: "B"},

--- a/coordinator_test.go
+++ b/coordinator_test.go
@@ -17,9 +17,82 @@
 package main
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+func TestNewCoordinator(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		schemas []*tableSchema
+		want    []*table
+	}{
+		{
+			desc: "Flat",
+			schemas: []*tableSchema{
+				{tableName: "A", parentTableName: ""},
+				{tableName: "B", parentTableName: ""},
+			},
+			want: []*table{
+				{tableName: "A"},
+				{tableName: "B"},
+			},
+		},
+		{
+			desc: "Parent-child relationship",
+			schemas: []*tableSchema{
+				{tableName: "A", parentTableName: ""},
+				{tableName: "B", parentTableName: ""},
+				{tableName: "C", parentTableName: "B"},
+			},
+			want: []*table{
+				{tableName: "A"},
+				{tableName: "B", childTables: []*table{{tableName: "C"}}},
+			},
+		},
+		{
+			desc: "Only child table specified",
+			schemas: []*tableSchema{
+				{tableName: "C", parentTableName: "B"},
+			},
+			want: []*table{
+				{tableName: "C"},
+			},
+		},
+		{
+			desc: "Only child table specified in two levels",
+			schemas: []*tableSchema{
+				{tableName: "C", parentTableName: "B"},
+				{tableName: "D", parentTableName: "C"},
+			},
+			want: []*table{
+				{tableName: "C", childTables: []*table{{tableName: "D"}}},
+			},
+		},
+		{
+			desc: "Foreign Key reference",
+			schemas: []*tableSchema{
+				{tableName: "A", parentTableName: ""},
+				{tableName: "B", parentTableName: "", referencedBy: []string{}},
+				{tableName: "C", parentTableName: "", referencedBy: []string{"B"}},
+			},
+			want: []*table{
+				{tableName: "A"},
+				{tableName: "B"},
+				{tableName: "C", referencedBy: []*table{{tableName: "B"}}},
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			coordinator := newCoordinator(test.schemas, nil)
+			got := coordinator.tables
+			if !compareTables(got, test.want) {
+				t.Errorf("invalid tables: got = %#v, want = %#v", got, test.want)
+			}
+		})
+	}
+}
 
 func TestFindDeletableTables(t *testing.T) {
 	for _, tt := range []struct {
@@ -244,4 +317,24 @@ func extractTableNames(tables []*table) []string {
 		names[i] = table.tableName
 	}
 	return names
+}
+
+func compareTables(tables1, tables2 []*table) bool {
+	if len(tables1) != len(tables2) {
+		return false
+	}
+	for i := 0; i < len(tables1); i++ {
+		t1 := tables1[i]
+		t2 := tables2[i]
+		if t1.tableName != t2.tableName {
+			return false
+		}
+		if !compareTables(t1.childTables, t2.childTables) {
+			return false
+		}
+		if !compareTables(t1.referencedBy, t2.referencedBy) {
+			return false
+		}
+	}
+	return true
 }

--- a/main.go
+++ b/main.go
@@ -82,7 +82,10 @@ func run(ctx context.Context, projectID, instanceID, databaseID string, quiet bo
 	if err != nil {
 		return fmt.Errorf("failed to create Cloud Spanner client: %v", err)
 	}
-	defer client.Close()
+	defer func() {
+		fmt.Fprintf(out, "Closing spanner client...\n")
+		client.Close()
+	}()
 
 	fmt.Fprintf(out, "Fetching table schema from %s\n", database)
 	schemas, err := fetchTableSchemas(ctx, client, targetTables, excludeTables)


### PR DESCRIPTION
## Overview
This PR fixes the issue where child tables are not deleted when only child tables are specified with `--tables` option.

## Result
Setup data:
```
spanner> INSERT into parent (parentkey,value) values (1,"hello");
Query OK, 1 rows affected (0.50 sec)

spanner> insert into child (parentkey, childkey, value) (select 1, childkey, "world" from unnest(generate_array(1,5000)) as childkey);
Query OK, 5000 rows affected (0.72 sec)
```

Delete:
```
$ spanner-truncate -p ${PROJECT_ID} -i ${INSTANCE_ID} -d ${DATABASE_ID} -t child -q
Fetching table schema from <redacted>
child

Rows in these tables will be deleted.
child: completed    12s [====================================================================] 100% (5,000 / 5,000)

Done! All rows have been deleted successfully.
Closing spanner client...
```

After deletion:
```
spanner> select count(*) from parent;
+---+
|   |
+---+
| 1 |
+---+
1 rows in set (1.07 msecs)

spanner> select count(*) from child;
+---+
|   |
+---+
| 0 |
+---+
1 rows in set (2.26 msecs)
```