### PR TITLE
Avoid "too many mutations" error when a child table has a global index

### DIFF
--- a/coordinator.go
+++ b/coordinator.go
@@ -41,6 +41,7 @@ func (t *table) isDeletable() bool {
 		if child.parentOnDeleteAction == deleteActionNoAction && child.deleter.status != statusCompleted {
 			return false
 		}
+		// Partitioned DML may not work perfectly if a child of the target table has global indexes.
 		if child.hasGlobalIndex && child.deleter.status != statusCompleted {
 			return false
 		}
@@ -121,8 +122,7 @@ func newCoordinator(schemas []*tableSchema, indexes []*indexSchema, client *span
 				tableName: schema.tableName,
 				client:    client,
 			},
-			referencedBy:   []*table{},
-			hasGlobalIndex: false,
+			referencedBy: []*table{},
 		}
 		tables = append(tables, t)
 		tableMap[schema.tableName] = t

--- a/coordinator.go
+++ b/coordinator.go
@@ -31,6 +31,7 @@ type table struct {
 	parentTableName      string
 	parentOnDeleteAction deleteActionType
 	referencedBy         []*table
+	hasGlobalIndex       bool
 	deleter              *deleter
 }
 
@@ -38,6 +39,9 @@ type table struct {
 func (t *table) isDeletable() bool {
 	for _, child := range t.childTables {
 		if child.parentOnDeleteAction == deleteActionNoAction && child.deleter.status != statusCompleted {
+			return false
+		}
+		if child.hasGlobalIndex && child.deleter.status != statusCompleted {
 			return false
 		}
 		if !child.isDeletable() {
@@ -105,7 +109,7 @@ type coordinator struct {
 	errChan chan error
 }
 
-func newCoordinator(schemas []*tableSchema, client *spanner.Client) *coordinator {
+func newCoordinator(schemas []*tableSchema, indexes []*indexSchema, client *spanner.Client) *coordinator {
 	var tables []*table
 	tableMap := map[string]*table{}
 	for _, schema := range schemas {
@@ -117,7 +121,8 @@ func newCoordinator(schemas []*tableSchema, client *spanner.Client) *coordinator
 				tableName: schema.tableName,
 				client:    client,
 			},
-			referencedBy: []*table{},
+			referencedBy:   []*table{},
+			hasGlobalIndex: false,
 		}
 		tables = append(tables, t)
 		tableMap[schema.tableName] = t
@@ -132,6 +137,15 @@ func newCoordinator(schemas []*tableSchema, client *spanner.Client) *coordinator
 		table := tableMap[schema.tableName]
 		for _, referencing := range schema.referencedBy {
 			table.referencedBy = append(table.referencedBy, tableMap[referencing])
+		}
+	}
+
+	// Mark tables that has at least one global index.
+	for _, idx := range indexes {
+		// A global index isn't interleaved in any table.
+		if idx.parentTableName == "" {
+			table := tableMap[idx.baseTableName]
+			table.hasGlobalIndex = true
 		}
 	}
 

--- a/coordinator.go
+++ b/coordinator.go
@@ -144,8 +144,9 @@ func newCoordinator(schemas []*tableSchema, indexes []*indexSchema, client *span
 	for _, idx := range indexes {
 		// A global index isn't interleaved in any table.
 		if idx.parentTableName == "" {
-			table := tableMap[idx.baseTableName]
-			table.hasGlobalIndex = true
+			if table, ok := tableMap[idx.baseTableName]; ok {
+				table.hasGlobalIndex = true
+			}
 		}
 	}
 

--- a/coordinator_test.go
+++ b/coordinator_test.go
@@ -35,7 +35,6 @@ func TestNewCoordinator(t *testing.T) {
 				{tableName: "A", parentTableName: ""},
 				{tableName: "B", parentTableName: ""},
 			},
-			indexes: nil,
 			want: []*table{
 				{tableName: "A"},
 				{tableName: "B"},
@@ -48,7 +47,6 @@ func TestNewCoordinator(t *testing.T) {
 				{tableName: "B", parentTableName: ""},
 				{tableName: "C", parentTableName: "B"},
 			},
-			indexes: nil,
 			want: []*table{
 				{tableName: "A"},
 				{tableName: "B", childTables: []*table{{tableName: "C"}}},
@@ -59,7 +57,6 @@ func TestNewCoordinator(t *testing.T) {
 			schemas: []*tableSchema{
 				{tableName: "C", parentTableName: "B"},
 			},
-			indexes: nil,
 			want: []*table{
 				{tableName: "C"},
 			},
@@ -70,7 +67,6 @@ func TestNewCoordinator(t *testing.T) {
 				{tableName: "C", parentTableName: "B"},
 				{tableName: "D", parentTableName: "A"},
 			},
-			indexes: nil,
 			want: []*table{
 				{tableName: "C"},
 				{tableName: "D"},
@@ -82,7 +78,6 @@ func TestNewCoordinator(t *testing.T) {
 				{tableName: "C", parentTableName: "B"},
 				{tableName: "D", parentTableName: "C"},
 			},
-			indexes: nil,
 			want: []*table{
 				{tableName: "C", childTables: []*table{{tableName: "D"}}},
 			},
@@ -94,7 +89,6 @@ func TestNewCoordinator(t *testing.T) {
 				{tableName: "B", parentTableName: "", referencedBy: []string{}},
 				{tableName: "C", parentTableName: "", referencedBy: []string{"B"}},
 			},
-			indexes: nil,
 			want: []*table{
 				{tableName: "A"},
 				{tableName: "B"},

--- a/coordinator_test.go
+++ b/coordinator_test.go
@@ -105,7 +105,7 @@ func TestNewCoordinator(t *testing.T) {
 				{indexName: "Bi", baseTableName: "B", parentTableName: "B"},
 			},
 			want: []*table{
-				{tableName: "A", childTables: []*table{{tableName: "B"}}},
+				{tableName: "A", hasGlobalIndex: false, childTables: []*table{{tableName: "B", hasGlobalIndex: false}}},
 			},
 		},
 		{
@@ -115,10 +115,10 @@ func TestNewCoordinator(t *testing.T) {
 				{tableName: "B", parentTableName: "A"},
 			},
 			indexes: []*indexSchema{
-				{indexName: "Bi", baseTableName: "B", parentTableName: "B"},
+				{indexName: "Bi", baseTableName: "B", parentTableName: ""},
 			},
 			want: []*table{
-				{tableName: "A", childTables: []*table{{tableName: "B"}}},
+				{tableName: "A", hasGlobalIndex: false, childTables: []*table{{tableName: "B", hasGlobalIndex: true}}},
 			},
 		},
 	} {
@@ -437,6 +437,9 @@ func compareTables(tables1, tables2 []*table) bool {
 		t1 := tables1[i]
 		t2 := tables2[i]
 		if t1.tableName != t2.tableName {
+			return false
+		}
+		if t1.hasGlobalIndex != t2.hasGlobalIndex {
 			return false
 		}
 		if !compareTables(t1.childTables, t2.childTables) {

--- a/deleter.go
+++ b/deleter.go
@@ -57,8 +57,11 @@ func (d *deleter) deleteRows(ctx context.Context) error {
 	return err
 }
 
+// When parent deletion started, change child status unless the child deletion has already completed.
 func (d *deleter) parentDeletionStarted() {
-	d.status = statusCascadeDeleting
+	if d.status != statusCompleted {
+		d.status = statusCascadeDeleting
+	}
 }
 
 // startRowCountUpdater starts periodical row count in another goroutine.

--- a/main.go
+++ b/main.go
@@ -104,7 +104,12 @@ func run(ctx context.Context, projectID, instanceID, databaseID string, quiet bo
 		fmt.Fprintf(out, "Rows in these tables will be deleted.\n")
 	}
 
-	coordinator := newCoordinator(schemas, client)
+	indexes, err := fetchIndexSchemas(ctx, client)
+	if err != nil {
+		return fmt.Errorf("failed to fetch index schema: %v", err)
+	}
+
+	coordinator := newCoordinator(schemas, indexes, client)
 	coordinator.start(ctx)
 
 	// Show progress bars.


### PR DESCRIPTION
In most cases, spanner-truncate can avoid "too many mutations" failure because of the use of [Partitioned DML](https://cloud.google.com/spanner/docs/dml-partitioned), which is designed for bulk updates/deletes.
However, at the time of this writing, Partitioned DML may cause "too many mutations" failure if a target database contains a child table has at least one global index. A global index means a secondary index which isn't interleaved in any table.

To deal with this behavior, this PR would tweak the coordinator and control the order of deletion according to the use of global indexes. To be specific, spanner-truncate will delete a child table that has global index(es) first, then delete its parent table. The implementation strategy is similar to the existing code to handle interleaved tables with `PARENT ON DELETE NO ACTION`.


## How this PR improves spanner-truncate

ddl.sql
```
CREATE TABLE users (
  user_id INT64 NOT NULL,
  name STRING(32) NOT NULL,
) PRIMARY KEY (user_id);

CREATE TABLE user_items (
  user_id INT64 NOT NULL,
  item_id INT64 NOT NULL,
  name STRING(32) NOT NULL,
) PRIMARY KEY (user_id, item_id),
  INTERLEAVE IN PARENT users ON DELETE CASCADE;

-- Define a Global Index (= not interleaved) on the child table
CREATE INDEX UserItemsByName ON user_items(name);
```

dummydata.sql
```
INSERT INTO users (user_id, name) values (1, "myname");
INSERT INTO user_items (user_id, item_id, name) (SELECT 1, id, "myitem" FROM UNNEST(generate_array(    1, 5000)) as id);
INSERT INTO user_items (user_id, item_id, name) (SELECT 1, id, "myitem" FROM UNNEST(generate_array( 5001,10000)) as id);
INSERT INTO user_items (user_id, item_id, name) (SELECT 1, id, "myitem" FROM UNNEST(generate_array(10001,15000)) as id);
INSERT INTO user_items (user_id, item_id, name) (SELECT 1, id, "myitem" FROM UNNEST(generate_array(15001,20000)) as id);
INSERT INTO user_items (user_id, item_id, name) (SELECT 1, id, "myitem" FROM UNNEST(generate_array(20001,25000)) as id);
```

Prep test environment

```
$ gcloud spanner databases create <db-name> --project <pj-name> --instance <inst-name>
$ spanner-cli -p <pj-name> -i <inst-name> -d <db-name> -f ddl.sql
$ spanner-cli -p <pj-name> -i <inst-name> -d <db-name> -f dummydata.sql
$ spanner-cli -p <pj-name> -i <inst-name> -d <db-name> -e 'select count(1) from users; select count(1) from user_items;'
1
25000
```

Before changes on this PR

```
$ ./spanner-truncate -p <pj-name> -i <inst-name> -d <db-name> -q
Fetching table schema from projects/<pj-name>/instances/<inst-name>/databases/<db-name>
user_items
users

Rows in these tables will be deleted.
users:      deleting      0s [--------------------------------------------------------------------]   0% (0 / 1)
user_items: deleting      0s [--------------------------------------------------------------------]   0% (0 / 25,000)
Closing spanner client...
ERROR: failed to delete: rpc error: code = InvalidArgument desc = The transaction contains too many mutations. Insert and update operations count with the multiplicity of the number of columns they affect. For example, inserting values into one key column and four non-key columns count as five mutations total for the insert. Delete and delete range operations count as one mutation regardless of the number of columns affected. The total mutation count includes any changes to indexes that the transaction generates. Please reduce the number of writes, or use fewer indexes. (Maximum number: 20000)%
```

After changes on this PR

```
$ ./spanner-truncate -p <pj-name> -i <inst-name> -d <db-name> -q
Fetching table schema from projects/<pj-name>/instances/<inst-name>/databases/<db-name>
user_items
users

Rows in these tables will be deleted.
users:      completed     6s [====================================================================] 100% (1 / 1)
user_items: completed     4s [====================================================================] 100% (25,000 / 25,000)

Done! All rows have been deleted successfully.
Closing spanner client...
```
