### PR TITLE
Include descendants tables that will be deleted in cascade #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Application Options:
   -i, --instance= (required) Cloud Spanner Instance ID. [$SPANNER_INSTANCE_ID]
   -d, --database= (required) Cloud Spanner Database ID. [$SPANNER_DATABASE_ID]
   -q, --quiet     Disable all interactive prompts.
-  -t, --tables=   Comma separated table names to be truncated. Default to truncate all tables if not specified.
-  -e, --exclude-tables Comma separated table names to be exempted from truncating. 'tables' and 'exclude-tables' cannot co-exist. If interleaved tables are specified, the parent table is also excluded.
+  -t, --tables=   Comma separated table names to be truncated. Default to truncate all tables if not specified. If an interleaved table is specified, its descendants tables are also truncated.
+  -e, --exclude-tables Comma separated table names to be exempted from truncating. 'tables' and 'exclude-tables' cannot co-exist. If an interleaved table is specified, its ancestors tables are also excluded.
 Help Options:
   -h, --help      Show this help message
 ```

--- a/truncate/table_schema_test.go
+++ b/truncate/table_schema_test.go
@@ -101,7 +101,7 @@ func TestTargetFilterTableSchemas(t *testing.T) {
 		want         []*tableSchema
 	}{
 		{
-			desc:         "Include descendants tables by tracing up to the bottommost level.",
+			desc:         "Include descendants tables by tracing down to the bottommost level.",
 			schemas:      []*tableSchema{singers, albums, songs, t1, t2, t3},
 			targetTables: []string{singers.tableName},
 			want:         []*tableSchema{singers, albums, songs},
@@ -125,7 +125,7 @@ func TestTargetFilterTableSchemas(t *testing.T) {
 			want:         []*tableSchema{singers, albums, songs, t1, t2, t3},
 		},
 		{
-			desc:         "Do not include descendants tables that will not delete target tables in cascade.",
+			desc:         "Do not include descendants tables that will not be deleted in cascade.",
 			schemas:      []*tableSchema{singers, albums, songs, t4, t5, t6},
 			targetTables: []string{singers.tableName, t4.tableName},
 			want:         []*tableSchema{singers, albums, songs, t4},


### PR DESCRIPTION
Hello! 
This PR addresses Issue #18 related to cascade deletion on interleaved tables.  
Please have a look and review!

# Related Issue
- fixes #18 - Descendant tables to be cascade deleted are not printed in the console as target tables.

# Changes
- Fix `targetFilterTableSchemas` to include descendants tables that will be deleted in cascade.
- Add tests for `targetFilterTableSchemas` to ensure cascade deletable descendants are also targeted.
- Fix Readme to describe this change.
- A clear distinction was made between `Parent/Child Tables` and `Ancestors/Descendants Tables`.